### PR TITLE
Track active browsing sessions and durations; normalize stats and update popup display

### DIFF
--- a/Link_Visit_Counter_v11/background.js
+++ b/Link_Visit_Counter_v11/background.js
@@ -1,47 +1,143 @@
-// Initialize storage if empty
+const STORAGE_KEYS = {
+  DAILY_COUNTS: "dailyCounts",
+  TOTAL_COUNTS: "totalCounts",
+  ACTIVE_SESSIONS: "activeSessions"
+};
+
 chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.local.get(["dailyCounts", "totalCounts"], (result) => {
-    if (!result.dailyCounts) {
-      chrome.storage.local.set({ dailyCounts: {}, totalCounts: {} });
+  chrome.storage.local.get(
+    [STORAGE_KEYS.DAILY_COUNTS, STORAGE_KEYS.TOTAL_COUNTS, STORAGE_KEYS.ACTIVE_SESSIONS],
+    (result) => {
+      chrome.storage.local.set({
+        [STORAGE_KEYS.DAILY_COUNTS]: result[STORAGE_KEYS.DAILY_COUNTS] || {},
+        [STORAGE_KEYS.TOTAL_COUNTS]: result[STORAGE_KEYS.TOTAL_COUNTS] || {},
+        [STORAGE_KEYS.ACTIVE_SESSIONS]: result[STORAGE_KEYS.ACTIVE_SESSIONS] || {}
+      });
     }
-  });
+  );
 });
 
-// Listen for tab updates
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  if (changeInfo.status === "complete" && tab.url) {
-    const url = new URL(tab.url);
-    const hostname = url.hostname;
+function getTodayKey() {
+  return new Date().toLocaleDateString();
+}
 
-    // Get current date
-    const today = new Date().toLocaleDateString();
+function ensureStatsEntry(entry) {
+  if (typeof entry === "number") {
+    return { visits: entry, timeMs: 0 };
+  }
 
-    // Update daily and total counts
-    chrome.storage.local.get(["dailyCounts", "totalCounts"], (result) => {
-      const dailyCounts = result.dailyCounts || {};
-      const totalCounts = result.totalCounts || {};
+  return {
+    visits: entry?.visits || 0,
+    timeMs: entry?.timeMs || 0
+  };
+}
 
-      // Update daily count
+function startSession(tabId, hostname) {
+  chrome.storage.local.get(
+    [STORAGE_KEYS.DAILY_COUNTS, STORAGE_KEYS.TOTAL_COUNTS, STORAGE_KEYS.ACTIVE_SESSIONS],
+    (result) => {
+      const today = getTodayKey();
+      const dailyCounts = result[STORAGE_KEYS.DAILY_COUNTS] || {};
+      const totalCounts = result[STORAGE_KEYS.TOTAL_COUNTS] || {};
+      const activeSessions = result[STORAGE_KEYS.ACTIVE_SESSIONS] || {};
+
       if (!dailyCounts[today]) {
         dailyCounts[today] = {};
       }
-      dailyCounts[today][hostname] = (dailyCounts[today][hostname] || 0) + 1;
 
-      // Update total count
-      totalCounts[hostname] = (totalCounts[hostname] || 0) + 1;
+      dailyCounts[today][hostname] = ensureStatsEntry(dailyCounts[today][hostname]);
+      totalCounts[hostname] = ensureStatsEntry(totalCounts[hostname]);
 
-      // Save back to storage
-      chrome.storage.local.set({ dailyCounts, totalCounts });
-    });
-  }
-});
+      dailyCounts[today][hostname].visits += 1;
+      totalCounts[hostname].visits += 1;
 
-// Reset daily counts at midnight
-function resetDailyCounts() {
-  chrome.storage.local.set({ dailyCounts: {} });
+      activeSessions[tabId] = {
+        hostname,
+        startTime: Date.now()
+      };
+
+      chrome.storage.local.set({
+        [STORAGE_KEYS.DAILY_COUNTS]: dailyCounts,
+        [STORAGE_KEYS.TOTAL_COUNTS]: totalCounts,
+        [STORAGE_KEYS.ACTIVE_SESSIONS]: activeSessions
+      });
+    }
+  );
 }
 
-// Schedule reset at midnight
+function stopSession(tabId) {
+  chrome.storage.local.get(
+    [STORAGE_KEYS.DAILY_COUNTS, STORAGE_KEYS.TOTAL_COUNTS, STORAGE_KEYS.ACTIVE_SESSIONS],
+    (result) => {
+      const activeSessions = result[STORAGE_KEYS.ACTIVE_SESSIONS] || {};
+      const session = activeSessions[tabId];
+
+      if (!session) {
+        return;
+      }
+
+      const elapsedMs = Math.max(0, Date.now() - session.startTime);
+      const today = getTodayKey();
+      const dailyCounts = result[STORAGE_KEYS.DAILY_COUNTS] || {};
+      const totalCounts = result[STORAGE_KEYS.TOTAL_COUNTS] || {};
+
+      if (!dailyCounts[today]) {
+        dailyCounts[today] = {};
+      }
+
+      dailyCounts[today][session.hostname] = ensureStatsEntry(dailyCounts[today][session.hostname]);
+      totalCounts[session.hostname] = ensureStatsEntry(totalCounts[session.hostname]);
+
+      dailyCounts[today][session.hostname].timeMs += elapsedMs;
+      totalCounts[session.hostname].timeMs += elapsedMs;
+
+      delete activeSessions[tabId];
+
+      chrome.storage.local.set({
+        [STORAGE_KEYS.DAILY_COUNTS]: dailyCounts,
+        [STORAGE_KEYS.TOTAL_COUNTS]: totalCounts,
+        [STORAGE_KEYS.ACTIVE_SESSIONS]: activeSessions
+      });
+    }
+  );
+}
+
+function getHostname(urlString) {
+  try {
+    const url = new URL(urlString);
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+
+    return url.hostname;
+  } catch {
+    return null;
+  }
+}
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status !== "complete" || !tab.url) {
+    return;
+  }
+
+  const hostname = getHostname(tab.url);
+  if (!hostname) {
+    return;
+  }
+
+  stopSession(tabId);
+  startSession(tabId, hostname);
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  stopSession(tabId);
+});
+
+function resetDailyCounts() {
+  chrome.storage.local.set({ [STORAGE_KEYS.DAILY_COUNTS]: {} });
+}
+
 const now = new Date();
 const midnight = new Date(now);
 midnight.setHours(24, 0, 0, 0);
@@ -49,5 +145,5 @@ const timeUntilMidnight = midnight - now;
 
 setTimeout(() => {
   resetDailyCounts();
-  setInterval(resetDailyCounts, 24 * 60 * 60 * 1000); // Reset every 24 hours
+  setInterval(resetDailyCounts, 24 * 60 * 60 * 1000);
 }, timeUntilMidnight);

--- a/Link_Visit_Counter_v11/popup.js
+++ b/Link_Visit_Counter_v11/popup.js
@@ -3,17 +3,14 @@ document.addEventListener("DOMContentLoaded", () => {
   const totalTab = document.getElementById("totalTab");
   const content = document.getElementById("content");
 
-  // Load daily counts by default
   loadDailyCounts();
 
-  // Switch to daily counts
   dailyTab.addEventListener("click", () => {
     dailyTab.classList.add("active");
     totalTab.classList.remove("active");
     loadDailyCounts();
   });
 
-  // Switch to total counts
   totalTab.addEventListener("click", () => {
     totalTab.classList.add("active");
     dailyTab.classList.remove("active");
@@ -23,7 +20,7 @@ document.addEventListener("DOMContentLoaded", () => {
   function loadDailyCounts() {
     chrome.storage.local.get("dailyCounts", (result) => {
       const today = new Date().toLocaleDateString();
-      const dailyCounts = result.dailyCounts[today] || {};
+      const dailyCounts = result.dailyCounts?.[today] || {};
       displayCounts(dailyCounts);
     });
   }
@@ -35,30 +32,48 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
+  function normalizeStats(stats) {
+    if (typeof stats === "number") {
+      return { visits: stats, timeMs: 0 };
+    }
+
+    return {
+      visits: stats?.visits || 0,
+      timeMs: stats?.timeMs || 0
+    };
+  }
+
+  function formatDuration(timeMs) {
+    const totalSeconds = Math.floor(timeMs / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+
   function displayCounts(counts) {
     content.innerHTML = "";
 
-    // Convert counts object to an array and sort by count (descending)
-    const sortedEntries = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    const sortedEntries = Object.entries(counts).sort((a, b) => {
+      const statsA = normalizeStats(a[1]);
+      const statsB = normalizeStats(b[1]);
+      return statsB.visits - statsA.visits;
+    });
 
-    // Display sorted counts with favicons
-    sortedEntries.forEach(([hostname, count]) => {
+    sortedEntries.forEach(([hostname, rawStats]) => {
+      const stats = normalizeStats(rawStats);
       const div = document.createElement("div");
-      div.className = "site-entry"; // Add the class for styling
+      div.className = "site-entry";
 
-      // Create favicon image element
       const favicon = document.createElement("img");
       favicon.src = `https://www.google.com/s2/favicons?domain=${hostname}`;
 
-      // Create text element for hostname and count
       const text = document.createElement("span");
-      text.textContent = `${hostname}: ${count}`;
+      text.textContent = `${hostname}: ${stats.visits} visits • ${formatDuration(stats.timeMs)}`;
 
-      // Append favicon and text to the div
       div.appendChild(favicon);
       div.appendChild(text);
-
-      // Append the div to the content container
       content.appendChild(div);
     });
   }


### PR DESCRIPTION
### Motivation
- Introduce per-session tracking to measure time spent on sites in addition to visit counts to provide richer usage metrics.
- Normalize stored counters to a consistent object shape so previous numeric counts are migrated and time can be accumulated reliably.
- Centralize storage keys and harden URL handling to ignore non-HTTP(S) schemes and avoid invalid hostnames.

### Description
- Add `STORAGE_KEYS`, `getTodayKey`, `ensureStatsEntry`, `startSession`, `stopSession`, and `getHostname` helpers and replace ad-hoc storage keys and logic in `background.js` to manage `dailyCounts`, `totalCounts`, and `activeSessions`.
- Track active sessions in `activeSessions` with `startTime` and update both `visits` and `timeMs` for daily and total stats when sessions stop or tabs update/close, with migration support from numeric counts to `{ visits, timeMs }` shape via `ensureStatsEntry`.
- Replace the previous `tabs.onUpdated` behavior to stop any prior session for a tab and start a new one only for valid `http(s)` hostnames, and handle `tabs.onRemoved` to stop sessions and accumulate time.
- Update `popup.js` to normalize stats with `normalizeStats`, format durations with `formatDuration`, display `visits` and human-readable `timeMs`, sort entries by `visits`, and use optional chaining for safer access to `dailyCounts`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5e4c64140832fbfdc19dc77d173f0)